### PR TITLE
Fix miss-leading documents.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,11 @@ led1.close()
 ``` python
 from periphery import PWM
 
-# Open PWM channel 0, pin 10
-pwm = PWM(0, 10)
+# Open PWM(pin,channel) PWM pin 1, channel 0   
+# You can figure out the pin number by run  'ls /sys/class/pwm' list of pwmchip# - # will be the pin number
+# You can figure out how many channel are supported for the pin 
+# by run 'cat /sys/class/pwm/pwmchip0/npwm' - pwmchip0 as example
+pwm = PWM(1, 0)
 
 # Set frequency to 1 kHz
 pwm.frequency = 1e3


### PR DESCRIPTION
 Not sure if any body has followed the documents to worked with PWM, but it is totally misleading. 
 I spent hours doing research finally was able to figure this part out by looking at the snippet code provided by @scottellis https://github.com/scottellis/pwmpy

In the code:
Original mapping

`PWM(channel, pin)` is  **WRONG**

instead, it actually should work like this: 
`PWM(channel-->chip/pin, pin-->channel)`

e.g. 
with the example from the README
```
# Open channel 0, for pin 10 
PWM(0,10) --> it sounds like should export the following :
/sys/class/pwm/pwmchip10/pwm0
```

but what it is actually doing is: (open chip/pin 0, with the 11th channel) 
```
/sys/class/pwm/pwmchip0/pwm10 
```

so the paramer should be passed in as this 

# PWM(pin, channel)

so the the example from the README become 
```
# Open channel 0, for pin 10 
PWM(10,0)  
/sys/class/pwm/pwmchip10/pwm0
```


add additional info:
```
# You can figure out the pin number by run  'ls /sys/class/pwm' list of pwmchip# - # will be the pin number
# You can figure out how many channel are supported for the pin 
# by run 'cat /sys/class/pwm/pwmchip0/npwm' - pwmchip0 as example
```