### PR TITLE
Fix receiving of binary data with unknown length.

### DIFF
--- a/periphery/serial.py
+++ b/periphery/serial.py
@@ -103,7 +103,7 @@ class Serial(object):
 
         parity = parity.lower()
 
-        (iflag, oflag, cflag, lflag, ispeed, ospeed, cc) = (0, 0, 0, 0, 0, 0, [0] * 32)
+        iflag, oflag, cflag, lflag, ispeed, ospeed, cc = termios.tcgetattr(self._fd)
 
         ###
         # iflag
@@ -194,25 +194,16 @@ class Serial(object):
         """
         data = b""
 
-        # Read length bytes if timeout is None
-
-        # Read up to length bytes if timeout is not None
-        while True:
-            if timeout is not None:
-                # Select
-                (rlist, _, _) = select.select([self._fd], [], [], timeout)
-                # If timeout
-                if self._fd not in rlist:
-                    break
-
-            try:
-                data += os.read(self._fd, length - len(data))
-            except OSError as e:
-                raise SerialError(e.errno, "Reading serial port: " + e.strerror)
-
-            if len(data) == length:
-                break
-
+        if timeout is not None:
+            # Select
+            (rlist, _, _) = select.select([self._fd], [], [], timeout)
+            # If timeout
+            if self._fd not in rlist:
+                return data
+        try:
+            data = os.read(self._fd, length)
+        except OSError as e:
+            raise SerialError(e.errno, "Reading serial port: " + e.strerror)
         return data
 
     def write(self, data):
@@ -634,7 +625,81 @@ class Serial(object):
     :type: bool
     """
 
-    # String representation
+    def _get_vtime(self):
+        try:
+            iflag, oflag, cflag, lflag, ispeed, ospeed, cc = termios.tcgetattr(self._fd)
+        except termios.error as e:
+            raise SerialError(e.errno, "Getting serial port attributes: " + e.strerror)
+        return float(cc[termios.VTIME]) / 10.0
 
+    def _set_vtime(self, val):
+        if type(val) not in (int, float):
+            raise TypeError("Given type of `vtime` should be `int` or `float`")
+        val = float(val)
+        if not (0.0 <= val <= 25.5):
+            raise ValueError("Value of a `vtime` not in range 0 .. 25.5 seconds")
+        try:
+            iflag, oflag, cflag, lflag, ispeed, ospeed, cc = termios.tcgetattr(self._fd)
+        except termios.error as e:
+            raise SerialError(e.errno, "Setting serial port attributes: " + e.strerror)
+        cc[termios.VTIME] = int(float(val) * 10.0)
+        try:
+            termios.tcsetattr(self._fd, termios.TCSANOW, [iflag, oflag, cflag, lflag, ispeed, ospeed, cc])
+        except termios.error as e:
+            raise SerialError(e.errno, "Setting serial port attributes: " + e.strerror)
+
+    vtime = property(_get_vtime, _set_vtime)
+    """ Inter-char timeout in seconds. An inter-char timer is started when a
+        character arrives, and it counts up in a second units. It's reset
+        whenever new data arrives, so rapidly-arriving data never gives the
+        intercharacter timer a chance to count very high. It's only after the
+        last character of a burst - when the line is quiet - that the timer
+        really gets counting. When it reaches vtime, the user's request has
+        been satisfied and the read() returns. This provides exactly the
+        behavior we want when dealing with bursty data: collect data while
+        it's arriving rapidly, but when it calms down, give us what you got.
+        
+    Raises:
+        SerialError: if an I/O or OS error occurs.
+        ValueError: if `vtime` not in range of 0 .. 25.5 seconds
+        TypeError: if given type of `vtime` is not `int` or `float`  
+    :type: float
+    """
+
+    def _get_vmin(self):
+        try:
+            iflag, oflag, cflag, lflag, ispeed, ospeed, cc = termios.tcgetattr(self._fd)
+        except termios.error as e:
+            raise SerialError(e.errno, "Getting serial port attributes: " + e.strerror)
+        return cc[termios.VMIN]
+
+    def _set_vmin(self, val):
+        if type(val) is not int:
+            raise TypeError("Given type of `vmin` should be `int`")
+        if not (0 <= val <= 255):
+            raise ValueError("Value of a `vmin` not in range 0 .. 255 ")
+        try:
+            iflag, oflag, cflag, lflag, ispeed, ospeed, cc = termios.tcgetattr(self._fd)
+        except termios.error as e:
+            raise SerialError(e.errno, "Setting serial port attributes: " + e.strerror)
+        cc[termios.VMIN] = val
+        try:
+            termios.tcsetattr(self._fd, termios.TCSANOW, [iflag, oflag, cflag, lflag, ispeed, ospeed, cc])
+        except termios.error as e:
+            raise SerialError(e.errno, "Setting serial port attributes: " + e.strerror)
+
+    vmin = property(_get_vmin, _set_vmin)
+    """ Minimum number of bytes to continue read operation. In blocking read mode
+        (timeout=None) it allows not to return control from the `read` method if
+        at least the number of bytes specified by this field is not received.   
+    
+    Raises:
+        SerialError: if an I/O or OS error occurs.
+        ValueError: if given value of the `vmin` is not in range 0 .. 255
+        TypeError: if given type of `vmin` is not `int`  
+    :type: int
+    """
+
+    # String representation
     def __str__(self):
         return "Serial (device=%s, fd=%d, baudrate=%d, databits=%d, parity=%s, stopbits=%d, xonxoff=%s, rtscts=%s)" % (self.devpath, self.fd, self.baudrate, self.databits, self.parity, self.stopbits, str(self.xonxoff), str(self.rtscts))


### PR DESCRIPTION
This commit adds the ability to receive data in binary format with undefined length. To determine the end of the data block, the character interval is used. This is the most expected behavior when receiving data, because it allows you to receive blocks of data in the format in which they were transmitted. Without this commit, ingestion occurs before the buffer is filled with the expected number of bytes, which is almost always useless. More detailed description is here:
http://unixwiz.net/techtips/termios-vmin-vtime.html