### PR TITLE
gpio: properly accept timeout=None in GPIO.poll()

### DIFF
--- a/periphery/gpio.py
+++ b/periphery/gpio.py
@@ -176,7 +176,10 @@ class GPIO(object):
             TypeError: if `timeout` type is not None or int.
 
         """
-        if not isinstance(timeout, (int, float, type(None))):
+        if timeout is None:
+            timeout = -1
+
+        if not isinstance(timeout, (int, float)):
             raise TypeError("Invalid timeout type, should be integer, float, or None.")
 
         # Setup epoll


### PR DESCRIPTION
Calling poll of an epoll instance with timeout being None triggers a
TypeError:

	$ python -c 'import select; select.epoll().poll(timeout=None)'
	Traceback (most recent call last):
	  File "<string>", line 1, in <module>
	TypeError: a float is required

Fix this by passing -1 as timeout if None is given which has the
semantic of wait indefinitely.

Closes: https://github.com/vsergeev/python-periphery/issues/29