### PR TITLE
i2c: fix ioctl buffer size

### DIFF
--- a/periphery/i2c.py
+++ b/periphery/i2c.py
@@ -76,7 +76,7 @@ class I2C(object):
         self._devpath = devpath
 
         # Query supported functions
-        buf = array.array('I', [0])
+        buf = array.array('L', [0])
         try:
             fcntl.ioctl(self._fd, I2C._I2C_IOC_FUNCS, buf, True)
         except (OSError, IOError) as e:


### PR DESCRIPTION
The I2C_FUNCS ioctl expects an unsigned long output argument[1]. However, we currently create a buffer using the 'I' (unsigned int) specifier. On platforms where sizeof(unsigned int) < sizeof(unsigned long), this results in a buffer that is too small.

This has always been a problem but with Python 3.14, the ioctl interface has some logic to detect this kind of buffer overflow[2], causing a SystemError to be raised when trying to create a new I2C object.

Fix the type specifier to align with what the ioctl expects.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/i2c/dev-interface.rst?h=v7.0-rc2#n124
[2] https://github.com/python/cpython/commit/c2eaeee3dc3306ca486b0377b07b1a957584b691